### PR TITLE
Feature: Live Paint session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
+NODE_ENV="your_environment" #dev/prod
 BOT_TOKEN="your_bot_token"
 CLIENT_ID="your_bot_client_id" #for registering slash commands
+GUILD_ID="your_guild_id" #for guild-specific commands during development
+IP_SITE="localhost" #IP address where the web server will run

--- a/package-lock.json
+++ b/package-lock.json
@@ -4813,9 +4813,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/public/paint.css
+++ b/public/paint.css
@@ -1,0 +1,139 @@
+.paint-page {
+    margin: 0;
+    background: #f6f1e7;
+    color: #2b2b2b;
+}
+
+.paint-shell {
+    height: 100vh;
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+}
+
+.paint-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 20px;
+    background: #f3dfb9;
+    border-bottom: 3px solid #e4c88e;
+    font-family: 'Comic Sans MS', 'Trebuchet MS', cursive;
+}
+
+.paint-title {
+    font-size: 20px;
+    font-weight: 700;
+}
+
+.paint-id {
+    font-size: 12px;
+    opacity: 0.7;
+    margin-left: 8px;
+}
+
+.paint-timer {
+    font-size: 14px;
+    background: #fff8e8;
+    border: 2px solid #e4c88e;
+    padding: 6px 10px;
+    border-radius: 10px;
+}
+
+.paint-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+    padding: 12px 20px;
+    background: #fff8e8;
+    border-bottom: 2px dashed #d9b96d;
+    font-family: 'Trebuchet MS', Arial, sans-serif;
+}
+
+.tool-group {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.tool-label {
+    font-weight: 700;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.color-palette {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.color-swatch {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    border: 2px solid rgba(0, 0, 0, 0.25);
+    cursor: pointer;
+    transition: transform 0.1s ease;
+}
+
+.color-swatch.active {
+    transform: scale(1.08);
+    box-shadow: 0 0 0 2px #2b2b2b;
+}
+
+.tool-button {
+    background: #f3dfb9;
+    border: 2px solid #d9b96d;
+    padding: 6px 12px;
+    border-radius: 8px;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.tool-button.active {
+    background: #ffecbf;
+    box-shadow: inset 0 0 0 2px #b07b00;
+}
+
+#brushSize {
+    accent-color: #c88b00;
+}
+
+.size-value {
+    min-width: 24px;
+    text-align: center;
+    font-weight: 700;
+}
+
+.paint-canvas-wrap {
+    position: relative;
+    padding: 16px 20px 20px;
+    background: repeating-linear-gradient(
+        -45deg,
+        #fdf9f2,
+        #fdf9f2 12px,
+        #f7efe1 12px,
+        #f7efe1 24px
+    );
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.paint-canvas-frame {
+    width: min(100%, 160vh);
+    aspect-ratio: 16 / 9;
+}
+
+#paintCanvas {
+    width: 100%;
+    height: 100%;
+    background: #ffffff;
+    border: 4px solid #2b2b2b;
+    border-radius: 16px;
+    box-shadow: 6px 6px 0 #2b2b2b;
+    cursor: crosshair;
+    display: block;
+}

--- a/public/paint.css
+++ b/public/paint.css
@@ -97,6 +97,13 @@
     box-shadow: inset 0 0 0 2px #b07b00;
 }
 
+.tool-button.disabled,
+.tool-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    filter: grayscale(0.5);
+}
+
 #brushSize {
     accent-color: #c88b00;
 }
@@ -136,4 +143,10 @@
     box-shadow: 6px 6px 0 #2b2b2b;
     cursor: crosshair;
     display: block;
+}
+
+.message-info {
+    font-size: 12px;
+    color: rgb(110, 110, 110);
+    margin-left: 12px;
 }

--- a/public/paint.js
+++ b/public/paint.js
@@ -1,0 +1,211 @@
+/* eslint-disable no-undef */
+const page = document.body;
+const sessionId = page.dataset.sessionId;
+const sessionTimeRemaining = Number(page.dataset.timeRemaining || 0);
+
+const canvas = document.getElementById('paintCanvas');
+const ctx = canvas.getContext('2d');
+const palette = document.getElementById('colorPalette');
+const timeRemainingEl = document.getElementById('timeRemaining');
+const brushSizeInput = document.getElementById('brushSize');
+const sizeValue = document.getElementById('sizeValue');
+const eraserToggle = document.getElementById('eraserToggle');
+const clearCanvas = document.getElementById('clearCanvas');
+
+const colors = ['#1f1f1f', '#ef4444', '#f97316', '#facc15', '#22c55e', '#3b82f6', '#8b5cf6', '#ec4899'];
+let currentColor = colors[0];
+let isEraser = false;
+let drawing = false;
+let lastPoint = null;
+let socket;
+
+function formatTime(ms) {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = String(totalSeconds % 60).padStart(2, '0');
+    return `${minutes}:${seconds}`;
+}
+
+function updateTimer() {
+    const now = Date.now();
+    const endTime = now + sessionTimeRemaining;
+    const tick = () => {
+        const remaining = endTime - Date.now();
+        timeRemainingEl.textContent = formatTime(remaining);
+        if (remaining <= 0) {
+            timeRemainingEl.textContent = '0:00';
+            return;
+        }
+        requestAnimationFrame(tick);
+    };
+    tick();
+}
+
+function resizeCanvas() {
+    const rect = canvas.getBoundingClientRect();
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = rect.width * ratio;
+    canvas.height = rect.height * ratio;
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+}
+
+function setColor(color) {
+    currentColor = color;
+    isEraser = false;
+    eraserToggle.classList.remove('active');
+    document.querySelectorAll('.color-swatch').forEach(swatch => {
+        swatch.classList.toggle('active', swatch.dataset.color === color);
+    });
+}
+
+function getPointerPosition(event) {
+    const rect = canvas.getBoundingClientRect();
+    return {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+        rect
+    };
+}
+
+function startDraw(event) {
+    drawing = true;
+    const { x, y } = getPointerPosition(event);
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    lastPoint = { x, y };
+}
+
+function endDraw() {
+    drawing = false;
+    ctx.beginPath();
+    lastPoint = null;
+}
+
+function draw(event) {
+    if (!drawing) return;
+    const { x, y, rect } = getPointerPosition(event);
+
+    const brushSize = Number(brushSizeInput.value);
+    ctx.lineWidth = brushSize;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.globalCompositeOperation = isEraser ? 'destination-out' : 'source-over';
+    ctx.strokeStyle = isEraser ? '#000000' : currentColor;
+
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+
+    if (socket && socket.readyState === WebSocket.OPEN && lastPoint) {
+        const stroke = {
+            points: [
+                { x: lastPoint.x / rect.width, y: lastPoint.y / rect.height },
+                { x: x / rect.width, y: y / rect.height }
+            ],
+            color: currentColor,
+            width: brushSize,
+            widthRatio: brushSize / rect.width,
+            tool: isEraser ? 'eraser' : 'pen'
+        };
+        socket.send(JSON.stringify({ type: 'paint:stroke', stroke }));
+    }
+
+    lastPoint = { x, y };
+}
+
+function drawStroke(stroke) {
+    const rect = canvas.getBoundingClientRect();
+    const points = stroke.points || [];
+    if (points.length < 2) return;
+
+    const lineWidth = stroke.widthRatio
+        ? stroke.widthRatio * rect.width
+        : (stroke.width || 3);
+
+    ctx.lineWidth = lineWidth;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.globalCompositeOperation = stroke.tool === 'eraser' ? 'destination-out' : 'source-over';
+    ctx.strokeStyle = stroke.tool === 'eraser' ? '#000000' : (stroke.color || '#000000');
+
+    ctx.beginPath();
+    ctx.moveTo(points[0].x * rect.width, points[0].y * rect.height);
+    ctx.lineTo(points[1].x * rect.width, points[1].y * rect.height);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.globalCompositeOperation = 'source-over';
+}
+
+function connectWebSocket() {
+    const wsUrl = `ws://${window.location.host}?sessionId=${sessionId}`;
+    socket = new WebSocket(wsUrl);
+
+    socket.addEventListener('message', (event) => {
+        const data = JSON.parse(event.data);
+        if (data.type === 'paint:init') {
+            if (Array.isArray(data.strokes)) {
+                data.strokes.forEach(drawStroke);
+            }
+        }
+
+        if (data.type === 'paint:stroke') {
+            drawStroke(data.stroke);
+        }
+
+        if (data.type === 'paint:clear') {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+        }
+    });
+
+    socket.addEventListener('close', () => {
+        setTimeout(connectWebSocket, 2000);
+    });
+
+    socket.addEventListener('error', () => {
+        socket.close();
+    });
+}
+
+function setupPalette() {
+    colors.forEach(color => {
+        const swatch = document.createElement('button');
+        swatch.type = 'button';
+        swatch.className = 'color-swatch';
+        swatch.style.background = color;
+        swatch.dataset.color = color;
+        swatch.addEventListener('click', () => setColor(color));
+        palette.appendChild(swatch);
+    });
+    setColor(colors[0]);
+}
+
+brushSizeInput.addEventListener('input', () => {
+    sizeValue.textContent = brushSizeInput.value;
+});
+
+eraserToggle.addEventListener('click', () => {
+    isEraser = !isEraser;
+    eraserToggle.classList.toggle('active', isEraser);
+});
+
+clearCanvas.addEventListener('click', () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: 'paint:clear' }));
+    }
+});
+
+canvas.addEventListener('pointerdown', startDraw);
+canvas.addEventListener('pointerup', endDraw);
+canvas.addEventListener('pointerleave', endDraw);
+canvas.addEventListener('pointermove', draw);
+
+window.addEventListener('resize', () => {
+    resizeCanvas();
+});
+
+setupPalette();
+updateTimer();
+resizeCanvas();
+connectWebSocket();

--- a/public/paint.js
+++ b/public/paint.js
@@ -184,10 +184,8 @@ brushSizeInput.addEventListener('input', () => {
     sizeValue.textContent = brushSizeInput.value;
 });
 
-eraserToggle.addEventListener('click', () => {
-    isEraser = !isEraser;
-    eraserToggle.classList.toggle('active', isEraser);
-});
+eraserToggle.disabled = true;
+eraserToggle.classList.add('disabled');
 
 clearCanvas.addEventListener('click', () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,6 +11,45 @@ body {
     color: white;
 }
 
+.paint-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.paint-overlay-timer {
+    position: absolute;
+    top: 24px;
+    left: 24px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #ffffff;
+    font-family: Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+    font-size: 32px;
+    padding: 8px 14px;
+    border-radius: 10px;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+.paint-overlay.hidden {
+    display: none;
+}
+
+.paint-overlay-frame {
+    width: min(100%, 160vh);
+    aspect-ratio: 16 / 9;
+}
+
+#paintOverlayCanvas {
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    display: block;
+}
+
 .message {
     position: relative;
     width: 100vw;

--- a/src/commands/paint.js
+++ b/src/commands/paint.js
@@ -1,0 +1,54 @@
+import { SlashCommandBuilder, EmbedBuilder } from "discord.js";
+import { config } from "../config/config.js";
+
+export const data = new SlashCommandBuilder()
+    .setName('paint')
+    .setDescription('Start a collaborative painting session');
+
+export async function execute(interaction, commands, paintSessionManager) {
+    const channelId = interaction.channelId;
+
+    console.log(paintSessionManager);
+    const existingSession = paintSessionManager.getSessionByChannel(channelId);
+    if (existingSession) {
+        return interaction.reply({
+            content: `⚠️ Une session est déjà en cours dans ce channel !`,
+            ephemeral: true
+        });
+    }
+
+    const onSessionEnd = async () => {
+        try {
+            const channel = await interaction.client.channels.fetch(channelId);
+            if (channel && channel.isTextBased()) {
+                const embed = new EmbedBuilder()
+                    .setTitle('🎨 Session de peinture terminée')
+                    .setDescription(`Le temps est écoulé ! Merci à tous.`)
+                    .setColor(0xff0000)
+                    .setTimestamp();
+                await channel.send({ embeds: [embed] });
+            }
+        } catch (err) {
+            console.error("Erreur lors de la notification de fin de session:", err);
+        }
+    };
+    const sessionInfo = paintSessionManager.createSession(channelId, onSessionEnd);
+    if (!sessionInfo) {
+        return interaction.reply({ content: `⚠️ Impossible de démarrer une nouvelle session.`, ephemeral: true });
+    }
+
+    const paintUrl = `http://<IP>:${config.port}/paint/${sessionInfo.sessionId}`;
+
+    const embed = new EmbedBuilder()
+        .setTitle('Session de peinture collaborative démarrée')
+        .setDescription(`Une nouvelle session de peinture collaborative a été démarrée dans ce channel !\n\n`
+            + `Cliquez [ici](${paintUrl}) pour rejoindre la session et commencer à peindre ensemble.`)
+        .addFields(
+            { name: 'Durée', value: '2 min 30', inline: true },
+            { name: 'Lien OBS', value: `http://<IP>:3000/view/${channelId}`, inline: true }
+        )
+        .setColor(0x00ff00)
+        .setTimestamp();
+
+    await interaction.reply({ embeds: [embed] });
+}

--- a/src/commands/paint.js
+++ b/src/commands/paint.js
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder, EmbedBuilder } from "discord.js";
 import { config } from "../config/config.js";
+import stateManager from "../services/stateManager.js";
 
 export const data = new SlashCommandBuilder()
     .setName('paint')
@@ -8,7 +9,6 @@ export const data = new SlashCommandBuilder()
 export async function execute(interaction, commands, paintSessionManager) {
     const channelId = interaction.channelId;
 
-    console.log(paintSessionManager);
     const existingSession = paintSessionManager.getSessionByChannel(channelId);
     if (existingSession) {
         return interaction.reply({
@@ -17,8 +17,33 @@ export async function execute(interaction, commands, paintSessionManager) {
         });
     }
 
-    const onSessionEnd = async () => {
+    const sendToChannel = (payload) => {
+        const clients = stateManager.webSocketClients.get(channelId);
+        if (!clients) return;
+        const data = JSON.stringify(payload);
+        clients.forEach(client => {
+            if (client.readyState === 1) {
+                client.send(data);
+            }
+        });
+    };
+
+    const sendToSession = (sessionId, payload) => {
+        const clients = stateManager.paintWebSocketClients.get(sessionId);
+        if (!clients) return;
+        const data = JSON.stringify(payload);
+        clients.forEach(client => {
+            if (client.readyState === 1) {
+                client.send(data);
+            }
+        });
+    };
+
+    const onSessionEnd = async (sessionId) => {
         try {
+            sendToSession(sessionId, { type: 'paint:end' });
+            sendToChannel({ type: 'paint:end' });
+
             const channel = await interaction.client.channels.fetch(channelId);
             if (channel && channel.isTextBased()) {
                 const embed = new EmbedBuilder()

--- a/src/commands/paint.js
+++ b/src/commands/paint.js
@@ -62,7 +62,7 @@ export async function execute(interaction, commands, paintSessionManager) {
         return interaction.reply({ content: `⚠️ Impossible de démarrer une nouvelle session.`, ephemeral: true });
     }
 
-    const paintUrl = `http://<IP>:${config.port}/paint/${sessionInfo.sessionId}`;
+    const paintUrl = `http://${config.ip_site}:${config.port}/paint/${sessionInfo.sessionId}`;
 
     const embed = new EmbedBuilder()
         .setTitle('Session de peinture collaborative démarrée')
@@ -70,7 +70,7 @@ export async function execute(interaction, commands, paintSessionManager) {
             + `Cliquez [ici](${paintUrl}) pour rejoindre la session et commencer à peindre ensemble.`)
         .addFields(
             { name: 'Durée', value: '2 min 30', inline: true },
-            { name: 'Lien OBS', value: `http://<IP>:3000/view/${channelId}`, inline: true }
+            { name: 'Lien OBS', value: `http://${config.ip_site}:3000/view/${channelId}`, inline: true }
         )
         .setColor(0x00ff00)
         .setTimestamp();

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from 'discord.js';
 import stateManager from '../services/stateManager.js';
+import { config } from '../config/config.js';
 
 export const data = new SlashCommandBuilder()
     .setName('register')
@@ -13,6 +14,6 @@ export async function execute(interaction) {
 
     await interaction.reply(
         `Channel **${interaction.channel.name}** enregistré pour le serveur **${interaction.guild.name}**.`
-        + `\n\nLien OBS: http://<IP>:3000/view/${channelId}`
+        + `\n\nLien OBS: http://${config.ip_site}:3000/view/${channelId}`
     );
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -4,6 +4,7 @@ dotenv.config();
 const config = {
     port: process.env.PORT || 3000,
     env: process.env.NODE_ENV || 'dev',
+    ip_site: process.env.IP_SITE || 'localhost',
     botToken: process.env.BOT_TOKEN,
     botClientId: process.env.CLIENT_ID,
     botGuildId: process.env.GUILD_ID,

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { config } from './config/config.js';
 import setupExpressServer from './server/express.js';
 import WebSocketService from './services/websocket.js';
 import CommandHandler from './services/commandHandler.js';
+import paintSessionManager from './services/paintSession.js';
 
 // Setup Discord bot
 const bot = new Client({
@@ -11,7 +12,7 @@ const bot = new Client({
 
 
 // Setup command handler
-const commandHandler = new CommandHandler();
+const commandHandler = new CommandHandler({ paintSessionManager });
 commandHandler.loadCommands(); // This will load all commands from the commands directory
 
 // Bot event handlers

--- a/src/server/express.js
+++ b/src/server/express.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import paintSession from '../services/paintSession.js';
 
 function setupExpressServer() {
     const app = express();
@@ -11,8 +12,17 @@ function setupExpressServer() {
         res.render('index', { channelId });
     });
 
-    // salut trop cool
+    app.get('/paint/:sessionId', (req, res) => {
+        const sessionId = req.params.sessionId;
+        const session = paintSession.getSession(sessionId);
 
+        if (!session || !session.isActive) {
+            return res.status(404).send('Session inexistante ou terminée.');
+        }
+
+        res.render('paint', { sessionId, session });
+    });
+    
     return app;
 }
 

--- a/src/services/commandHandler.js
+++ b/src/services/commandHandler.js
@@ -4,8 +4,9 @@ import { join } from 'path';
 import { config } from '../config/config.js';
 
 class CommandHandler {
-    constructor() {
+    constructor({ paintSessionManager }) {
         this.commands = new Collection();
+        this.paintSessionManager = paintSessionManager;
     }
 
     /**
@@ -32,7 +33,7 @@ class CommandHandler {
         }
 
         try {
-            await command.execute(interaction, this.getCommands());
+            await command.execute(interaction, this.getCommands(), this.paintSessionManager);
         } catch (error) {
             console.error(`Error executing command: ${error.message}`);
             await interaction.reply('Une erreur est survenue lors de l\'exécution de la commande.');

--- a/src/services/paintSession.js
+++ b/src/services/paintSession.js
@@ -6,7 +6,7 @@ const MAX_PARTICIPANTS = 15;
 class PaintSessionManager {
     constructor() {
         this.sessions = new Map(); // sessionId → SessionData
-        this.channelSessions = new Map(); // channelId → sessionId (pour éviter les doublons)
+        this.channelSessions = new Map(); // channelId → sessionId 
     }
 
     /**
@@ -73,7 +73,6 @@ class PaintSessionManager {
     getSessionByChannel(channelId) {
         const sessionId = this.channelSessions.get(channelId);
         if (!sessionId) return null;
-        console.log(this.getSession(sessionId));
         return this.getSession(sessionId);
     }
 
@@ -112,7 +111,7 @@ class PaintSessionManager {
      */
     addStroke(sessionId, strokeData) {
         const session = this.sessions.get(sessionId);
-        if (!session || !session.isActive) return false;
+        if (!session || !session.isActive) return null;
 
         const stroke = {
             id: randomUUID(),
@@ -120,10 +119,23 @@ class PaintSessionManager {
             points: strokeData.points,
             color: strokeData.color || '#000000',
             width: strokeData.width || 3,
+            widthRatio: strokeData.widthRatio || null,
             tool: strokeData.tool || 'pen'
         };
 
         session.strokes.push(stroke);
+        return stroke;
+    }
+
+    /**
+     * Efface tous les traits d'une session
+     * @param {string} sessionId
+     * @returns {boolean}
+     */
+    clearStrokes(sessionId) {
+        const session = this.sessions.get(sessionId);
+        if (!session || !session.isActive) return false;
+        session.strokes = [];
         return true;
     }
 

--- a/src/services/paintSession.js
+++ b/src/services/paintSession.js
@@ -1,0 +1,186 @@
+import { randomUUID } from 'crypto';
+
+const SESSION_DURATION_MS = 2 * 60 * 1000 + 30 * 1000; // 2min30
+const MAX_PARTICIPANTS = 15;
+
+class PaintSessionManager {
+    constructor() {
+        this.sessions = new Map(); // sessionId → SessionData
+        this.channelSessions = new Map(); // channelId → sessionId (pour éviter les doublons)
+    }
+
+    /**
+     * Crée une nouvelle session de dessin pour un channel
+     * @param {string} channelId - ID du channel Discord
+     * @param {function} onSessionEnd - Callback appelé à l'expiration
+     * @returns {{ sessionId: string, expiresAt: number } | null} - null si session déjà active
+     */
+    createSession(channelId, onSessionEnd = null) {
+        // Vérifier qu'aucune session n'est active sur ce channel
+        if (this.channelSessions.has(channelId)) {
+            return null;
+        }
+
+        const sessionId = randomUUID();
+        const expiresAt = Date.now() + SESSION_DURATION_MS;
+
+        const sessionData = {
+            sessionId,
+            channelId,
+            strokes: [],
+            participants: new Set(),
+            createdAt: Date.now(),
+            expiresAt,
+            isActive: true,
+            onSessionEnd,
+            timer: setTimeout(() => {
+                this.endSession(sessionId);
+            }, SESSION_DURATION_MS)
+        };
+
+        this.sessions.set(sessionId, sessionData);
+        this.channelSessions.set(channelId, sessionId);
+
+        return { sessionId, expiresAt };
+    }
+
+    /**
+     * Récupère une session par son ID
+     * @param {string} sessionId 
+     * @returns {object | null}
+     */
+    getSession(sessionId) {
+        const session = this.sessions.get(sessionId);
+        if (!session) return null;
+
+        return {
+            sessionId: session.sessionId,
+            channelId: session.channelId,
+            strokes: session.strokes,
+            participantCount: session.participants.size,
+            createdAt: session.createdAt,
+            expiresAt: session.expiresAt,
+            isActive: session.isActive,
+            timeRemaining: Math.max(0, session.expiresAt - Date.now())
+        };
+    }
+
+    /**
+     * Récupère la session active d'un channel
+     * @param {string} channelId 
+     * @returns {object | null}
+     */
+    getSessionByChannel(channelId) {
+        const sessionId = this.channelSessions.get(channelId);
+        if (!sessionId) return null;
+        console.log(this.getSession(sessionId));
+        return this.getSession(sessionId);
+    }
+
+    /**
+     * Ajoute un participant à une session
+     * @param {string} sessionId 
+     * @param {string} participantId 
+     * @returns {boolean} - false si session pleine ou inexistante
+     */
+    addParticipant(sessionId, participantId) {
+        const session = this.sessions.get(sessionId);
+        if (!session || !session.isActive) return false;
+        if (session.participants.size >= MAX_PARTICIPANTS) return false;
+
+        session.participants.add(participantId);
+        return true;
+    }
+
+    /**
+     * Retire un participant d'une session
+     * @param {string} sessionId 
+     * @param {string} participantId 
+     */
+    removeParticipant(sessionId, participantId) {
+        const session = this.sessions.get(sessionId);
+        if (session) {
+            session.participants.delete(participantId);
+        }
+    }
+
+    /**
+     * Ajoute un trait au canvas
+     * @param {string} sessionId 
+     * @param {object} strokeData - { points: [{x, y}], color: string, width: number, tool: 'pen'|'eraser' }
+     * @returns {boolean}
+     */
+    addStroke(sessionId, strokeData) {
+        const session = this.sessions.get(sessionId);
+        if (!session || !session.isActive) return false;
+
+        const stroke = {
+            id: randomUUID(),
+            timestamp: Date.now(),
+            points: strokeData.points,
+            color: strokeData.color || '#000000',
+            width: strokeData.width || 3,
+            tool: strokeData.tool || 'pen'
+        };
+
+        session.strokes.push(stroke);
+        return true;
+    }
+
+    /**
+     * Termine une session (manuellement ou par expiration)
+     * @param {string} sessionId 
+     * @returns {boolean}
+     */
+    endSession(sessionId) {
+        const session = this.sessions.get(sessionId);
+        if (!session) return false;
+
+        // Annuler le timer si encore actif
+        if (session.timer) {
+            clearTimeout(session.timer);
+            session.timer = null;
+        }
+
+        session.isActive = false;
+
+        // Appeler le callback si défini
+        if (session.onSessionEnd) {
+            session.onSessionEnd(session.sessionId, session.channelId);
+        }
+
+        // Nettoyer les références
+        this.channelSessions.delete(session.channelId);
+
+        // Garder la session en mémoire pour consultation (strokes finaux)
+        // Elle sera nettoyée après un délai ou manuellement
+        setTimeout(() => {
+            this.sessions.delete(sessionId);
+        }, 60 * 1000); // Cleanup après 1 minute
+
+        return true;
+    }
+
+    /**
+     * Vérifie si une session est encore active
+     * @param {string} sessionId 
+     * @returns {boolean}
+     */
+    isSessionActive(sessionId) {
+        const session = this.sessions.get(sessionId);
+        return session?.isActive ?? false;
+    }
+
+    /**
+     * Retourne les constantes de configuration
+     */
+    static get CONFIG() {
+        return {
+            SESSION_DURATION_MS,
+            MAX_PARTICIPANTS
+        };
+    }
+}
+
+// Export singleton
+export default new PaintSessionManager();

--- a/src/services/stateManager.js
+++ b/src/services/stateManager.js
@@ -2,6 +2,7 @@ class StateManager {
     constructor() {
         this.registeredServers = new Map();
         this.webSocketClients = new Map();
+        this.paintWebSocketClients = new Map();
     }
 
     registerChannel(guildId, channelId) {

--- a/src/services/websocket.js
+++ b/src/services/websocket.js
@@ -1,5 +1,7 @@
 import { WebSocketServer } from "ws";
+import { randomUUID } from 'crypto';
 import stateManager from "./stateManager.js";
+import paintSession from "./paintSession.js";
 
 class WebSocketService {
     constructor(server) {
@@ -13,12 +15,31 @@ class WebSocketService {
         this.wss.on('connection', (ws, req) => {
             const params = new URLSearchParams(req.url.split('?')[1]);
             const channelId = params.get('channelId');
+            const sessionId = params.get('sessionId');
+
+            if (sessionId) {
+                this.handlePaintConnection(ws, sessionId);
+                return;
+            }
 
             if (!stateManager.webSocketClients.has(channelId)) {
                 stateManager.webSocketClients.set(channelId, new Set());
             }
 
             stateManager.webSocketClients.get(channelId).add(ws);
+
+            // Si une session paint est active pour ce channel, envoyer l'état actuel
+            if (channelId) {
+                const session = paintSession.getSessionByChannel(channelId);
+                if (session && session.isActive) {
+                    ws.send(JSON.stringify({
+                        type: 'paint:init',
+                        sessionId: session.sessionId,
+                        strokes: session.strokes,
+                        timeRemaining: session.timeRemaining
+                    }));
+                }
+            }
 
             console.log(`Client connecté au channel ID: ${channelId}`);
 
@@ -29,6 +50,103 @@ class WebSocketService {
                 }
                 console.log(`Client déconnecté du channel ID: ${channelId}`);
             });
+        });
+    }
+
+    handlePaintConnection(ws, sessionId) {
+        const session = paintSession.getSession(sessionId);
+        if (!session || !session.isActive) {
+            ws.close(1008, 'Session inexistante ou terminée');
+            return;
+        }
+
+        if (!stateManager.paintWebSocketClients.has(sessionId)) {
+            stateManager.paintWebSocketClients.set(sessionId, new Set());
+        }
+
+        const participantId = randomUUID();
+        const added = paintSession.addParticipant(sessionId, participantId);
+        if (!added) {
+            ws.close(1008, 'Session pleine');
+            return;
+        }
+
+        ws.paintSessionId = sessionId;
+        ws.paintParticipantId = participantId;
+        stateManager.paintWebSocketClients.get(sessionId).add(ws);
+
+        ws.send(JSON.stringify({
+            type: 'paint:init',
+            strokes: session.strokes,
+            timeRemaining: session.timeRemaining
+        }));
+
+        // Informer les overlays OBS connectés au channel
+        this.broadcastToChannel(session.channelId, {
+            type: 'paint:init',
+            sessionId: session.sessionId,
+            strokes: session.strokes,
+            timeRemaining: session.timeRemaining
+        });
+
+        ws.on('message', (message) => {
+            try {
+                const payload = JSON.parse(message.toString());
+                if (payload.type === 'paint:stroke') {
+                    const stroke = paintSession.addStroke(sessionId, payload.stroke);
+                    if (!stroke) return;
+                    this.broadcastPaint(sessionId, ws, {
+                        type: 'paint:stroke',
+                        stroke
+                    });
+                    this.broadcastToChannel(session.channelId, {
+                        type: 'paint:stroke',
+                        stroke
+                    });
+                }
+
+                if (payload.type === 'paint:clear') {
+                    const cleared = paintSession.clearStrokes(sessionId);
+                    if (!cleared) return;
+                    this.broadcastPaint(sessionId, ws, { type: 'paint:clear' });
+                    this.broadcastToChannel(session.channelId, { type: 'paint:clear' });
+                }
+            } catch (err) {
+                console.error('Erreur WS paint:', err);
+            }
+        });
+
+        ws.on('close', () => {
+            paintSession.removeParticipant(sessionId, participantId);
+            const clients = stateManager.paintWebSocketClients.get(sessionId);
+            if (clients) {
+                clients.delete(ws);
+                if (clients.size === 0) {
+                    stateManager.paintWebSocketClients.delete(sessionId);
+                }
+            }
+        });
+    }
+
+    broadcastPaint(sessionId, sender, payload) {
+        const clients = stateManager.paintWebSocketClients.get(sessionId);
+        if (!clients) return;
+        const data = JSON.stringify(payload);
+        clients.forEach((client) => {
+            if (client !== sender && client.readyState === 1) {
+                client.send(data);
+            }
+        });
+    }
+
+    broadcastToChannel(channelId, payload) {
+        const clients = stateManager.webSocketClients.get(channelId);
+        if (!clients) return;
+        const data = JSON.stringify(payload);
+        clients.forEach((client) => {
+            if (client.readyState === 1) {
+                client.send(data);
+            }
         });
     }
 

--- a/tests/services/commandHandler.test.js
+++ b/tests/services/commandHandler.test.js
@@ -4,9 +4,15 @@ import {jest} from '@jest/globals'
 
 describe('CommandHandler', () => {
     let commandHandler;
+    let mockPaintSessionManager;
 
     beforeEach(() => {
-        commandHandler = new CommandHandler();
+        mockPaintSessionManager = {
+            createSession: jest.fn(),
+            getSession: jest.fn(),
+            endSession: jest.fn()
+        };
+        commandHandler = new CommandHandler({ paintSessionManager: mockPaintSessionManager });
     });
 
     describe('register', () => {
@@ -57,7 +63,7 @@ describe('CommandHandler', () => {
             commandHandler.register('test', mockCommand);
             await commandHandler.handle(mockInteraction);
 
-            expect(mockExecute).toHaveBeenCalledWith(mockInteraction, expect.any(Array));
+            expect(mockExecute).toHaveBeenCalledWith(mockInteraction, expect.any(Array), mockPaintSessionManager);
         });
 
         it('should handle non-existent command', async () => {

--- a/tests/services/paintSession.test.js
+++ b/tests/services/paintSession.test.js
@@ -179,7 +179,7 @@ describe('PaintSessionManager', () => {
             const result = paintSession.addStroke(sessionId, strokeData);
             const session = paintSession.getSession(sessionId);
 
-            expect(result).toBe(true);
+            expect(result).not.toBeNull();
             expect(session.strokes).toHaveLength(1);
             expect(session.strokes[0].points).toEqual(strokeData.points);
             expect(session.strokes[0].color).toBe('#FF0000');
@@ -199,6 +199,7 @@ describe('PaintSessionManager', () => {
 
             expect(session.strokes[0].color).toBe('#000000');
             expect(session.strokes[0].width).toBe(3);
+            expect(session.strokes[0].widthRatio).toBeNull();
             expect(session.strokes[0].tool).toBe('pen');
         });
 
@@ -207,11 +208,29 @@ describe('PaintSessionManager', () => {
             paintSession.endSession(sessionId);
             
             const result = paintSession.addStroke(sessionId, { points: [] });
-            expect(result).toBe(false);
+            expect(result).toBeNull();
         });
 
         it('should return false for invalid session', () => {
             const result = paintSession.addStroke('invalid-id', { points: [] });
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('clearStrokes', () => {
+        it('should clear strokes for active session', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            paintSession.addStroke(sessionId, { points: [{ x: 0, y: 0 }, { x: 1, y: 1 }] });
+
+            const result = paintSession.clearStrokes(sessionId);
+            const session = paintSession.getSession(sessionId);
+
+            expect(result).toBe(true);
+            expect(session.strokes).toHaveLength(0);
+        });
+
+        it('should return false for invalid session', () => {
+            const result = paintSession.clearStrokes('invalid-id');
             expect(result).toBe(false);
         });
     });

--- a/tests/services/paintSession.test.js
+++ b/tests/services/paintSession.test.js
@@ -1,0 +1,330 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import paintSession from '../../src/services/paintSession.js';
+
+describe('PaintSessionManager', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        // Reset l'état interne du singleton
+        paintSession.sessions.clear();
+        paintSession.channelSessions.clear();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    describe('createSession', () => {
+        it('should create a new session with unique ID', () => {
+            const channelId = 'channel-123';
+            const result = paintSession.createSession(channelId);
+
+            expect(result).not.toBeNull();
+            expect(result.sessionId).toBeDefined();
+            expect(typeof result.sessionId).toBe('string');
+            expect(result.expiresAt).toBeGreaterThan(Date.now());
+        });
+
+        it('should return null if session already exists for channel', () => {
+            const channelId = 'channel-123';
+            
+            const first = paintSession.createSession(channelId);
+            const second = paintSession.createSession(channelId);
+
+            expect(first).not.toBeNull();
+            expect(second).toBeNull();
+        });
+
+        it('should allow creating sessions for different channels', () => {
+            const result1 = paintSession.createSession('channel-1');
+            const result2 = paintSession.createSession('channel-2');
+
+            expect(result1).not.toBeNull();
+            expect(result2).not.toBeNull();
+            expect(result1.sessionId).not.toBe(result2.sessionId);
+        });
+
+        it('should set expiration to 2min30 from now', () => {
+            const now = Date.now();
+            const result = paintSession.createSession('channel-123');
+            
+            const expectedDuration = 2 * 60 * 1000 + 30 * 1000; // 150000ms
+            expect(result.expiresAt).toBe(now + expectedDuration);
+        });
+    });
+
+    describe('getSession', () => {
+        it('should return session data for valid sessionId', () => {
+            const channelId = 'channel-123';
+            const { sessionId } = paintSession.createSession(channelId);
+
+            const session = paintSession.getSession(sessionId);
+
+            expect(session).not.toBeNull();
+            expect(session.sessionId).toBe(sessionId);
+            expect(session.channelId).toBe(channelId);
+            expect(session.strokes).toEqual([]);
+            expect(session.participantCount).toBe(0);
+            expect(session.isActive).toBe(true);
+        });
+
+        it('should return null for invalid sessionId', () => {
+            const session = paintSession.getSession('invalid-id');
+            expect(session).toBeNull();
+        });
+
+        it('should calculate remaining time correctly', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            // Avancer le temps de 1 minute
+            jest.advanceTimersByTime(60 * 1000);
+            
+            const session = paintSession.getSession(sessionId);
+            const expectedRemaining = (2 * 60 * 1000 + 30 * 1000) - (60 * 1000); // 90000ms
+            
+            expect(session.timeRemaining).toBe(expectedRemaining);
+        });
+    });
+
+    describe('getSessionByChannel', () => {
+        it('should return session for active channel', () => {
+            const channelId = 'channel-123';
+            const { sessionId } = paintSession.createSession(channelId);
+
+            const session = paintSession.getSessionByChannel(channelId);
+
+            expect(session).not.toBeNull();
+            expect(session.sessionId).toBe(sessionId);
+        });
+
+        it('should return null for channel without session', () => {
+            const session = paintSession.getSessionByChannel('unknown-channel');
+            expect(session).toBeNull();
+        });
+    });
+
+    describe('addParticipant', () => {
+        it('should add participant to session', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            const result = paintSession.addParticipant(sessionId, 'user-1');
+            const session = paintSession.getSession(sessionId);
+
+            expect(result).toBe(true);
+            expect(session.participantCount).toBe(1);
+        });
+
+        it('should not add duplicate participant', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            paintSession.addParticipant(sessionId, 'user-1');
+            paintSession.addParticipant(sessionId, 'user-1');
+            
+            const session = paintSession.getSession(sessionId);
+            expect(session.participantCount).toBe(1);
+        });
+
+        it('should reject when session is full (15 max)', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            // Ajouter 15 participants
+            for (let i = 0; i < 15; i++) {
+                paintSession.addParticipant(sessionId, `user-${i}`);
+            }
+            
+            // Le 16ème doit être refusé
+            const result = paintSession.addParticipant(sessionId, 'user-16');
+            
+            expect(result).toBe(false);
+            expect(paintSession.getSession(sessionId).participantCount).toBe(15);
+        });
+
+        it('should return false for invalid session', () => {
+            const result = paintSession.addParticipant('invalid-id', 'user-1');
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('removeParticipant', () => {
+        it('should remove participant from session', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            paintSession.addParticipant(sessionId, 'user-1');
+            
+            paintSession.removeParticipant(sessionId, 'user-1');
+            
+            const session = paintSession.getSession(sessionId);
+            expect(session.participantCount).toBe(0);
+        });
+
+        it('should not throw for non-existent participant', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            expect(() => {
+                paintSession.removeParticipant(sessionId, 'unknown-user');
+            }).not.toThrow();
+        });
+    });
+
+    describe('addStroke', () => {
+        it('should add stroke with all properties', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            const strokeData = {
+                points: [{ x: 0, y: 0 }, { x: 10, y: 10 }],
+                color: '#FF0000',
+                width: 5,
+                tool: 'pen'
+            };
+            
+            const result = paintSession.addStroke(sessionId, strokeData);
+            const session = paintSession.getSession(sessionId);
+
+            expect(result).toBe(true);
+            expect(session.strokes).toHaveLength(1);
+            expect(session.strokes[0].points).toEqual(strokeData.points);
+            expect(session.strokes[0].color).toBe('#FF0000');
+            expect(session.strokes[0].width).toBe(5);
+            expect(session.strokes[0].tool).toBe('pen');
+        });
+
+        it('should use default values for missing properties', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            const strokeData = {
+                points: [{ x: 0, y: 0 }]
+            };
+            
+            paintSession.addStroke(sessionId, strokeData);
+            const session = paintSession.getSession(sessionId);
+
+            expect(session.strokes[0].color).toBe('#000000');
+            expect(session.strokes[0].width).toBe(3);
+            expect(session.strokes[0].tool).toBe('pen');
+        });
+
+        it('should return false for inactive session', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            paintSession.endSession(sessionId);
+            
+            const result = paintSession.addStroke(sessionId, { points: [] });
+            expect(result).toBe(false);
+        });
+
+        it('should return false for invalid session', () => {
+            const result = paintSession.addStroke('invalid-id', { points: [] });
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('endSession', () => {
+        it('should mark session as inactive', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            
+            paintSession.endSession(sessionId);
+            
+            const session = paintSession.getSession(sessionId);
+            expect(session.isActive).toBe(false);
+        });
+
+        it('should call onSessionEnd callback', () => {
+            const callback = jest.fn();
+            const channelId = 'channel-123';
+            const { sessionId } = paintSession.createSession(channelId, callback);
+            
+            paintSession.endSession(sessionId);
+
+            expect(callback).toHaveBeenCalledWith(sessionId, channelId);
+        });
+
+        it('should remove channel mapping', () => {
+            const channelId = 'channel-123';
+            const { sessionId } = paintSession.createSession(channelId);
+            
+            paintSession.endSession(sessionId);
+            
+            const sessionByChannel = paintSession.getSessionByChannel(channelId);
+            expect(sessionByChannel).toBeNull();
+        });
+
+        it('should allow creating new session for same channel after end', () => {
+            const channelId = 'channel-123';
+            paintSession.createSession(channelId);
+            paintSession.endSession(paintSession.getSessionByChannel(channelId).sessionId);
+            
+            const newSession = paintSession.createSession(channelId);
+            expect(newSession).not.toBeNull();
+        });
+
+        it('should return false for invalid session', () => {
+            const result = paintSession.endSession('invalid-id');
+            expect(result).toBe(false);
+        });
+
+        it('should cleanup session after 1 minute', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            paintSession.endSession(sessionId);
+            
+            // Session encore accessible juste après
+            expect(paintSession.getSession(sessionId)).not.toBeNull();
+            
+            // Avancer d'1 minute
+            jest.advanceTimersByTime(60 * 1000);
+            
+            // Session supprimée
+            expect(paintSession.getSession(sessionId)).toBeNull();
+        });
+    });
+
+    describe('automatic expiration', () => {
+        it('should auto-end session after 2min30', () => {
+            const callback = jest.fn();
+            const channelId = 'channel-123';
+            paintSession.createSession(channelId, callback);
+
+            // Avancer de 2min30
+            jest.advanceTimersByTime(2 * 60 * 1000 + 30 * 1000);
+
+            expect(callback).toHaveBeenCalled();
+            expect(paintSession.getSessionByChannel(channelId)).toBeNull();
+        });
+
+        it('should not auto-end if manually ended before', () => {
+            const callback = jest.fn();
+            const { sessionId } = paintSession.createSession('channel-123', callback);
+            
+            // Terminer manuellement après 1 minute
+            jest.advanceTimersByTime(60 * 1000);
+            paintSession.endSession(sessionId);
+            
+            // Avancer encore 2 minutes (au-delà de l'expiration initiale)
+            jest.advanceTimersByTime(2 * 60 * 1000);
+
+            // Callback appelé une seule fois (à l'appel manuel)
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('isSessionActive', () => {
+        it('should return true for active session', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            expect(paintSession.isSessionActive(sessionId)).toBe(true);
+        });
+
+        it('should return false for ended session', () => {
+            const { sessionId } = paintSession.createSession('channel-123');
+            paintSession.endSession(sessionId);
+            expect(paintSession.isSessionActive(sessionId)).toBe(false);
+        });
+
+        it('should return false for invalid session', () => {
+            expect(paintSession.isSessionActive('invalid-id')).toBe(false);
+        });
+    });
+
+    describe('CONFIG', () => {
+        it('should expose configuration constants', () => {
+            expect(paintSession.constructor.CONFIG.SESSION_DURATION_MS).toBe(150000);
+            expect(paintSession.constructor.CONFIG.MAX_PARTICIPANTS).toBe(15);
+        });
+    });
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>rawchat</title>
+    <title>LiveChat</title>
     <link rel="stylesheet" href="/styles.css">
 </head>
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,12 +9,25 @@
 </head>
 
 <body>
+    <div id="paintOverlay" class="paint-overlay hidden">
+        <div class="paint-overlay-timer" id="paintOverlayTimer">2:30</div>
+        <div class="paint-overlay-frame">
+            <canvas id="paintOverlayCanvas"></canvas>
+        </div>
+    </div>
     <div id="messages"></div>
 </body>
 <script>
     const channelId = "<%= channelId %>";
     const messagesContainer = document.getElementById('messages');
+    const paintOverlay = document.getElementById('paintOverlay');
+    const paintOverlayCanvas = document.getElementById('paintOverlayCanvas');
+    const paintOverlayCtx = paintOverlayCanvas.getContext('2d');
+    const paintOverlayTimer = document.getElementById('paintOverlayTimer');
     let contentTimer;
+    let paintSessionActive = false;
+    let paintTimerInterval = null;
+    let paintEndTime = null;
 
     function connectWebSocket() {
         const socket = new WebSocket(`ws://${window.location.hostname}:3000?channelId=${channelId}`);
@@ -25,6 +38,11 @@
 
         socket.addEventListener('message', (event) => {
             const messageData = JSON.parse(event.data);
+
+            if (messageData.type && messageData.type.startsWith('paint:')) {
+                handlePaintMessage(messageData);
+                return;
+            }
 
             if (messageData.action === 'stop') {
                 messagesContainer.innerHTML = '';
@@ -134,6 +152,107 @@
         return socket;
     }
     let socket = connectWebSocket();
+
+    function resizePaintOverlay() {
+        if (!paintOverlay) return;
+        const rect = paintOverlayCanvas.getBoundingClientRect();
+        const ratio = window.devicePixelRatio || 1;
+        paintOverlayCanvas.width = rect.width * ratio;
+        paintOverlayCanvas.height = rect.height * ratio;
+        paintOverlayCtx.setTransform(ratio, 0, 0, ratio, 0, 0);
+    }
+
+    function drawOverlayStroke(stroke) {
+        const rect = paintOverlayCanvas.getBoundingClientRect();
+        const points = stroke.points || [];
+        if (points.length < 2) return;
+
+        const lineWidth = stroke.widthRatio
+            ? stroke.widthRatio * rect.width
+            : (stroke.width || 3);
+
+        paintOverlayCtx.lineWidth = lineWidth;
+        paintOverlayCtx.lineCap = 'round';
+        paintOverlayCtx.lineJoin = 'round';
+        paintOverlayCtx.globalCompositeOperation = stroke.tool === 'eraser' ? 'destination-out' : 'source-over';
+        paintOverlayCtx.strokeStyle = stroke.tool === 'eraser' ? '#000000' : (stroke.color || '#000000');
+
+        paintOverlayCtx.beginPath();
+        paintOverlayCtx.moveTo(points[0].x * rect.width, points[0].y * rect.height);
+        paintOverlayCtx.lineTo(points[1].x * rect.width, points[1].y * rect.height);
+        paintOverlayCtx.stroke();
+        paintOverlayCtx.beginPath();
+        paintOverlayCtx.globalCompositeOperation = 'source-over';
+    }
+
+    function showPaintOverlay() {
+        paintOverlay.classList.remove('hidden');
+        paintSessionActive = true;
+        resizePaintOverlay();
+    }
+
+    function hidePaintOverlay() {
+        paintOverlay.classList.add('hidden');
+        paintSessionActive = false;
+        paintOverlayCtx.clearRect(0, 0, paintOverlayCanvas.width, paintOverlayCanvas.height);
+        if (paintTimerInterval) {
+            clearInterval(paintTimerInterval);
+            paintTimerInterval = null;
+        }
+        paintEndTime = null;
+    }
+
+    function formatTime(ms) {
+        const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = String(totalSeconds % 60).padStart(2, '0');
+        return `${minutes}:${seconds}`;
+    }
+
+    function startPaintTimer(timeRemaining) {
+        paintEndTime = Date.now() + (timeRemaining || 0);
+        if (paintTimerInterval) {
+            clearInterval(paintTimerInterval);
+        }
+        paintTimerInterval = setInterval(() => {
+            const remaining = paintEndTime - Date.now();
+            if (remaining <= 0) {
+                paintOverlayTimer.textContent = '0:00';
+                return;
+            }
+            paintOverlayTimer.textContent = formatTime(remaining);
+        }, 250);
+    }
+
+    function handlePaintMessage(messageData) {
+        if (!paintSessionActive && (messageData.type === 'paint:init' || messageData.type === 'paint:stroke')) {
+            showPaintOverlay();
+        }
+
+        if (messageData.type === 'paint:init') {
+            paintOverlayCtx.clearRect(0, 0, paintOverlayCanvas.width, paintOverlayCanvas.height);
+            if (Array.isArray(messageData.strokes)) {
+                messageData.strokes.forEach(drawOverlayStroke);
+            }
+            if (typeof messageData.timeRemaining === 'number') {
+                startPaintTimer(messageData.timeRemaining);
+            }
+        }
+
+        if (messageData.type === 'paint:stroke') {
+            drawOverlayStroke(messageData.stroke);
+        }
+
+        if (messageData.type === 'paint:clear') {
+            paintOverlayCtx.clearRect(0, 0, paintOverlayCanvas.width, paintOverlayCanvas.height);
+        }
+
+        if (messageData.type === 'paint:end') {
+            hidePaintOverlay();
+        }
+    }
+
+    window.addEventListener('resize', resizePaintOverlay);
 </script>
 
 </html>

--- a/views/paint.ejs
+++ b/views/paint.ejs
@@ -12,6 +12,7 @@
             <div class="paint-title">
                 🎨 Live Paint Session
                 <span class="paint-id">(<%= sessionId %>)</span>
+                <span class="message-info">J'ai pas réussi a faire marcher la gomme :(</span>
             </div>
             <div class="paint-timer">
                 Temps restant : <span id="timeRemaining"></span>

--- a/views/paint.ejs
+++ b/views/paint.ejs
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LiveChat - Live Paint !</title>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <h1 style="color: black;">Live Paint Session (<%= sessionId %>)</h1>
+    <p style="color: black;">Temps restant <%= session.timeRemaining %></p>
+
+    <canvas id="paintCanvas" width="800" height="600" style="border:1px solid #000000;"></canvas>
+
+    <script>
+        const canvas = document.getElementById('paintCanvas');
+        const ctx = canvas.getContext('2d');
+        let drawing = false;
+
+        canvas.addEventListener('mousedown', () => {
+            drawing = true;
+        });
+
+        canvas.addEventListener('mouseup', () => {
+            drawing = false;
+            ctx.beginPath();
+        });
+
+        canvas.addEventListener('mousemove', draw);
+
+        function draw(event) {
+            if (!drawing) return;
+
+            ctx.lineWidth = 5;
+            ctx.lineCap = 'round';
+            ctx.strokeStyle = '#000000';
+
+            ctx.lineTo(event.clientX - canvas.offsetLeft, event.clientY - canvas.offsetTop);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.moveTo(event.clientX - canvas.offsetLeft, event.clientY - canvas.offsetTop);
+        }
+    </script>
+</body>
+</html>

--- a/views/paint.ejs
+++ b/views/paint.ejs
@@ -4,42 +4,45 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LiveChat - Live Paint !</title>
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/paint.css">
 </head>
-<body>
-    <h1 style="color: black;">Live Paint Session (<%= sessionId %>)</h1>
-    <p style="color: black;">Temps restant <%= session.timeRemaining %></p>
+<body class="paint-page" data-session-id="<%= sessionId %>" data-time-remaining="<%= session.timeRemaining %>">
+    <div class="paint-shell">
+        <header class="paint-header">
+            <div class="paint-title">
+                🎨 Live Paint Session
+                <span class="paint-id">(<%= sessionId %>)</span>
+            </div>
+            <div class="paint-timer">
+                Temps restant : <span id="timeRemaining"></span>
+            </div>
+        </header>
 
-    <canvas id="paintCanvas" width="800" height="600" style="border:1px solid #000000;"></canvas>
+        <section class="paint-toolbar">
+            <div class="tool-group">
+                <span class="tool-label">Couleurs</span>
+                <div class="color-palette" id="colorPalette"></div>
+            </div>
 
-    <script>
-        const canvas = document.getElementById('paintCanvas');
-        const ctx = canvas.getContext('2d');
-        let drawing = false;
+            <div class="tool-group">
+                <span class="tool-label">Taille</span>
+                <input id="brushSize" type="range" min="2" max="18" value="5" />
+                <span class="size-value" id="sizeValue">5</span>
+            </div>
 
-        canvas.addEventListener('mousedown', () => {
-            drawing = true;
-        });
+            <div class="tool-group">
+                <button id="eraserToggle" class="tool-button" type="button">Gomme</button>
+                <button id="clearCanvas" class="tool-button" type="button">Effacer tout</button>
+            </div>
+        </section>
 
-        canvas.addEventListener('mouseup', () => {
-            drawing = false;
-            ctx.beginPath();
-        });
+        <main class="paint-canvas-wrap">
+            <div class="paint-canvas-frame">
+                <canvas id="paintCanvas"></canvas>
+            </div>
+        </main>
+    </div>
 
-        canvas.addEventListener('mousemove', draw);
-
-        function draw(event) {
-            if (!drawing) return;
-
-            ctx.lineWidth = 5;
-            ctx.lineCap = 'round';
-            ctx.strokeStyle = '#000000';
-
-            ctx.lineTo(event.clientX - canvas.offsetLeft, event.clientY - canvas.offsetTop);
-            ctx.stroke();
-            ctx.beginPath();
-            ctx.moveTo(event.clientX - canvas.offsetLeft, event.clientY - canvas.offsetTop);
-        }
-    </script>
+    <script src="/paint.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This pull request introduces a collaborative painting feature to the application, including a new `/paint` command for Discord, a web-based painting session UI, real-time drawing synchronization via WebSockets, and related configuration and infrastructure changes. The most important changes are grouped below:

**Collaborative Painting Feature Implementation:**

* Added a new `/paint` Discord slash command (`src/commands/paint.js`) that starts a collaborative painting session, manages session state, and posts session links and notifications in the channel.
* Implemented a new Express route to serve the collaborative paint page (`/paint/:sessionId`), which validates session existence and renders the painting UI. [[1]](diffhunk://#diff-358f195709a1c63b633f97facd7695b46e69ec4fc7c383fb3551a6ed9557eb26R2) [[2]](diffhunk://#diff-358f195709a1c63b633f97facd7695b46e69ec4fc7c383fb3551a6ed9557eb26L14-R24)
* Created a new client-side painting application (`public/paint.js`) that handles drawing, brush/color selection, timer, and real-time synchronization of strokes using WebSockets.
* Added a dedicated CSS file for the paint UI (`public/paint.css`) and overlay styles in the main stylesheet (`public/styles.css`) to provide a user-friendly and visually distinct painting experience. [[1]](diffhunk://#diff-8c5c86973f289076e017050f29ffe4066bc99824890a62d64cedb7f5d6c61307R1-R152) [[2]](diffhunk://#diff-c0957aceb7c1368cd9919f48a72240ae31b22112283b1bd4d38c66a55ed584b9R14-R52)

**Configuration and Infrastructure Updates:**

* Updated configuration to support customizable site IP address (`IP_SITE`) for generating correct public URLs in both bot messages and web pages, including changes in `.env.example`, config loading, and usage in commands. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R5) [[2]](diffhunk://#diff-edc1b6c6d093bf6dc7e864db320c10d2f1bdd56e1ac1cf9822ec89f893041c69R7) [[3]](diffhunk://#diff-f5103ccb33016ca1ff81d56779867dcc6300797b99fc21ce752850d2803b62a5R3) [[4]](diffhunk://#diff-f5103ccb33016ca1ff81d56779867dcc6300797b99fc21ce752850d2803b62a5L16-R17)
* Refactored the command handler and server setup to initialize and pass the `paintSessionManager` to commands, enabling shared session management across the bot and web server. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R6) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L14-R15) [[3]](diffhunk://#diff-20f9c27effebbdc1a8a3d4b79ddc31c6fb578c95397d61bd7e6b21d2858a7bb5L7-R9) [[4]](diffhunk://#diff-20f9c27effebbdc1a8a3d4b79ddc31c6fb578c95397d61bd7e6b21d2858a7bb5L35-R36)